### PR TITLE
Memory fault simulation

### DIFF
--- a/cmd/inject.go
+++ b/cmd/inject.go
@@ -24,6 +24,8 @@ var injectCmd = &cobra.Command{
 		switch faultType {
 		case "cpu":
 			return faults.InjectCPU(vmName, duration)
+		case "mem":
+			return faults.InjectMem(vmName, duration)
 		default:
 			return fmt.Errorf("unknown fault type: %s", faultType)
 		}

--- a/internal/faults/mem.go
+++ b/internal/faults/mem.go
@@ -1,0 +1,45 @@
+package faults
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
+
+func InjectMem(vmName string, duration int) error {
+	fmt.Printf("Memory leak spike for %d seconds\n", duration)
+
+	var memLeaks [][]byte
+
+	stopChannel := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stopChannel:
+				return
+			default:
+				kb := 1024
+				mb := 1024 * kb
+
+				memChunk := make([]byte, 100*mb)
+
+				for i := 0; i < len(memChunk); i += kb {
+					memChunk[i] = 1
+				}
+
+				memLeaks = append(memLeaks, memChunk)
+
+				fmt.Printf("Memory leakage at roughly %dMB\n", len(memLeaks)*100)
+				time.Sleep(500 * time.Millisecond)
+			}
+		}
+	}()
+
+	time.Sleep(time.Duration(duration) * time.Second)
+	close(stopChannel)
+
+	memLeaks = nil
+	runtime.GC()
+	fmt.Println("Memory leak Spike test complete.")
+	return nil
+}


### PR DESCRIPTION
This patch implements core logic to simulate memory faults. Given a virtual machine name input and a duration, we simulate memory leaks by allocating memory without automatically cleaning it up.
 
Testing & Verification:
- Run `go run main.go` with the `mem` argument and specify some the duration (under 10 seconds ideally, since this allocates memory fairly quickly)
- Use htop to confirm the high memory usage 